### PR TITLE
#23 Implement AD LDAP authentication

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dk1844
+* @dk1844 @jakipatryk

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Requires `ActiveDirectoryLDAPConfig(domain: String, url: String, searchFilter: S
 1. Run `openssl s_client -connect <ldaps_host>:<ldaps_port>`.
 2. Copy the part starting with `-----BEGIN CERTIFICATE-----` and ending with `-----END CERTIFICATE-----`. 
 3. Create file `ldapcert.pem` and paste content from (2) there.
-4. Run `keytool -import -file ldapcert.pem -alias ldaps -keystore <path_to_jdk>/Contents/Home/jre/lib/security/cacerts -storepass <password>`.
+4. Run `keytool -import -file ldapcert.pem -alias ldaps -keystore <path_to_jdk>/jre/lib/security/cacerts -storepass <password>` (default password is *changeit*).
 5. Enter `yes` when prompted.
 
 ## How to generate Code coverage report

--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ Swagger doc site is available at `http://localhost:8080/swagger-ui.html`
 It is available for download while running the service at `http://localhost:8080/v3/api-docs.yaml` - 
 gets generated from code (specifically from Spring annotations) 
 
+## Authentication Providers
+### ActiveDirectoryLDAPAuthenticationProvider
+Uses LDAP(s) to authenticate user in Active Directory and to fetch groups that this user belongs to.
+
+Requires `ActiveDirectoryLDAPConfig(domain: String, url: String, searchFilter: String)`.
+#### Tips
+##### How to obtain certificate for LDAPS
+1. Run `openssl s_client -connect <ldaps_host>:<ldaps_port>`.
+2. Copy the part starting with `-----BEGIN CERTIFICATE-----` and ending with `-----END CERTIFICATE-----`. 
+3. Create file `ldapcert.pem` and paste content from (2) there.
+4. Run `keytool -import -file ldapcert.pem -alias ldaps -keystore <path_to_jdk>/Contents/Home/jre/lib/security/cacerts -storepass <password>`.
+5. Enter `yes` when prompted.
+
 ## How to generate Code coverage report
 ```
 sbt jacoco

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -56,11 +56,6 @@ object Dependencies {
   // TODO bring actuator (health) endpoints in? - Issue #6
   //lazy val springBootStarterActuator = "org.springframework.boot" % "spring-boot-starter-actuator" % Versions.springBoot
 
-  // TODO LDAP/Kerberos integration: - Issue #8
-  // org.springframework.boot % {spring-boot-starter-security, spring-security-ldap, }
-  // org.springframework.security.kerberos % {spring-security-kerberos-web, spring-security-kerberos-client}
-
-
   lazy val scalaTest = "org.scalatest" %% "scalatest" % Versions.scalatest % Test
   lazy val springBootTest = "org.springframework.boot" % "spring-boot-starter-test" % Versions.springBoot % Test
   lazy val springBootSecurityTest = "org.springframework.security" % "spring-security-test" % Versions.spring % Test

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -41,6 +41,8 @@ object Dependencies {
   lazy val springBootTomcat =         "org.springframework.boot" % "spring-boot-starter-tomcat" % Versions.springBoot % Provided
   lazy val springBootSecurity =       "org.springframework.boot" % "spring-boot-starter-security" % Versions.springBoot
 
+  lazy val springSecurityLDAP = "org.springframework.security" % "spring-security-ldap" % Versions.spring
+
   lazy val jjwtApi = "io.jsonwebtoken" % "jjwt-api" % Versions.jjwt
   lazy val jjwtImpl = "io.jsonwebtoken" % "jjwt-impl" % Versions.jjwt % Runtime
   lazy val jjwtJackson = "io.jsonwebtoken" % "jjwt-jackson" % Versions.jjwt % Runtime
@@ -73,6 +75,8 @@ object Dependencies {
     springBootConfiguration,
     springBootTomcat,
     springBootSecurity,
+
+    springSecurityLDAP,
 
     jjwtApi,
     jjwtImpl,

--- a/publish.sbt
+++ b/publish.sbt
@@ -29,6 +29,12 @@ ThisBuild / developers := List(
     name  = "Daniel Kavan",
     email = "daniel.kavan@absa.africa",
     url   = url("https://github.com/dk1844")
+  ),
+  Developer(
+    id = "jakipatryk",
+    name = "Bartlomiej Baj",
+    email = "bartlomiej.baj@absa.africa",
+    url = url("https://github.com/jakipatryk")
   )
 )
 

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -3,3 +3,6 @@ spring.application.name = login-gateway
 logingw.rest.config.some-key = BETA
 logingw.rest.config.alg-name = RS256
 logingw.rest.config.exp-time = 2
+logingw.rest.auth.ad.ldap.domain = some.domain.com
+logingw.rest.auth.ad.ldap.url = ldaps://some.domain.com:636/
+logingw.rest.auth.ad.ldap.search-filter = (samaccountname={1})

--- a/service/src/main/scala/za/co/absa/logingw/model/User.scala
+++ b/service/src/main/scala/za/co/absa/logingw/model/User.scala
@@ -16,4 +16,4 @@
 
 package za.co.absa.logingw.model
 
-case class User(name: String, email: String, groups: Seq[String])
+case class User(name: String, email: Option[String], groups: Seq[String])

--- a/service/src/main/scala/za/co/absa/logingw/rest/SecurityConfig.scala
+++ b/service/src/main/scala/za/co/absa/logingw/rest/SecurityConfig.scala
@@ -29,7 +29,7 @@ import za.co.absa.logingw.rest.provider.ad.ldap.ActiveDirectoryLDAPAuthenticatio
 
 @Configuration
 @EnableWebSecurity
-class SecurityConfig() {
+class SecurityConfig {
 
   @Bean
   def filterChain(http: HttpSecurity): SecurityFilterChain = {

--- a/service/src/main/scala/za/co/absa/logingw/rest/SecurityConfig.scala
+++ b/service/src/main/scala/za/co/absa/logingw/rest/SecurityConfig.scala
@@ -59,14 +59,14 @@ class SecurityConfig {
   def authManager(http: HttpSecurity): AuthenticationManager = {
     val authenticationManagerBuilder = http.getSharedObject(classOf[AuthenticationManagerBuilder])
 
-    // TODO make it autowired but only if in confid AD LDAP provider is set up
+    // TODO make it autowired but only if in confid AD LDAP provider is set up (#28)
     val adLDAPConfig = ActiveDirectoryLDAPConfig(
       "some.domain.com",
       "ldaps://some.domain.com:636/",
       "(samaccountname={1})"
     )
 
-    // TODO: take which providers and in which order to use from config
+    // TODO: take which providers and in which order to use from config (#28)
     authenticationManagerBuilder
       // if it is not null, on auth failure infinite recursion happens
       .parentAuthenticationManager(null)

--- a/service/src/main/scala/za/co/absa/logingw/rest/SecurityConfig.scala
+++ b/service/src/main/scala/za/co/absa/logingw/rest/SecurityConfig.scala
@@ -16,7 +16,6 @@
 
 package za.co.absa.logingw.rest
 
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.{Bean, Configuration}
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
@@ -30,10 +29,7 @@ import za.co.absa.logingw.rest.provider.ad.ldap.ActiveDirectoryLDAPAuthenticatio
 
 @Configuration
 @EnableWebSecurity
-class SecurityConfig @Autowired()(
-                                   /* TODO autowire only if given provider specified in config */
-                                   adLDAPConfig: ActiveDirectoryLDAPConfig
-                                 ) {
+class SecurityConfig() {
 
   @Bean
   def filterChain(http: HttpSecurity): SecurityFilterChain = {
@@ -62,6 +58,13 @@ class SecurityConfig @Autowired()(
   @Bean
   def authManager(http: HttpSecurity): AuthenticationManager = {
     val authenticationManagerBuilder = http.getSharedObject(classOf[AuthenticationManagerBuilder])
+
+    // TODO make it autowired but only if in confid AD LDAP provider is set up
+    val adLDAPConfig = ActiveDirectoryLDAPConfig(
+      "some.domain.com",
+      "ldaps://some.domain.com:636/",
+      "(samaccountname={1})"
+    )
 
     // TODO: take which providers and in which order to use from config
     authenticationManagerBuilder

--- a/service/src/main/scala/za/co/absa/logingw/rest/config/ActiveDirectoryLDAPConfig.scala
+++ b/service/src/main/scala/za/co/absa/logingw/rest/config/ActiveDirectoryLDAPConfig.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package za.co.absa.logingw.rest.config
 
 import org.springframework.boot.context.properties.{ConfigurationProperties, ConstructorBinding}

--- a/service/src/main/scala/za/co/absa/logingw/rest/config/ActiveDirectoryLDAPConfig.scala
+++ b/service/src/main/scala/za/co/absa/logingw/rest/config/ActiveDirectoryLDAPConfig.scala
@@ -1,0 +1,15 @@
+package za.co.absa.logingw.rest.config
+
+import org.springframework.boot.context.properties.{ConfigurationProperties, ConstructorBinding}
+
+
+/**
+ * Configuration for AD LDAP(s) authentication provider.
+ *
+ * @param domain AD domain name, ex. "some.domain.com"
+ * @param url URL to AD LDAP, ex. "ldaps://some.domain.com:636/"
+ * @param searchFilter LDAP filter used when searching for groups, ex. "(samaccountname={1})"
+ */
+@ConstructorBinding
+@ConfigurationProperties(prefix = "logingw.rest.auth.ad.ldap")
+case class ActiveDirectoryLDAPConfig(domain: String, url: String, searchFilter: String)

--- a/service/src/main/scala/za/co/absa/logingw/rest/provider/DummyAuthenticationProvider.scala
+++ b/service/src/main/scala/za/co/absa/logingw/rest/provider/DummyAuthenticationProvider.scala
@@ -33,7 +33,7 @@ class DummyAuthenticationProvider extends AuthenticationProvider {
     val password = authentication.getCredentials.toString
 
     if(username == validUsername && password == validPassword) {
-      val principal = User(username, "test@abs.com", Seq.empty)
+      val principal = User(username, Some("test@abs.com"), Seq.empty)
       new UsernamePasswordAuthenticationToken(principal, password, Seq.empty[GrantedAuthority].asJava)
     } else throw new BadCredentialsException("Bad credentials provided.")
 

--- a/service/src/main/scala/za/co/absa/logingw/rest/provider/ad/ldap/ActiveDirectoryLDAPAuthenticationProvider.scala
+++ b/service/src/main/scala/za/co/absa/logingw/rest/provider/ad/ldap/ActiveDirectoryLDAPAuthenticationProvider.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.logingw.rest.provider.ad.ldap
+
+import org.springframework.ldap.core.DirContextOperations
+import org.springframework.security.authentication.{AuthenticationProvider, UsernamePasswordAuthenticationToken}
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.security.core.{Authentication, GrantedAuthority}
+import org.springframework.security.ldap.authentication.ad.{ActiveDirectoryLdapAuthenticationProvider => SpringSecurityActiveDirectoryLdapAuthenticationProvider}
+import org.springframework.security.ldap.userdetails.LdapUserDetailsMapper
+import za.co.absa.logingw.model.User
+import za.co.absa.logingw.rest.config.ActiveDirectoryLDAPConfig
+
+import java.util
+import scala.collection.JavaConverters._
+
+/**
+ * Enhances ActiveDirectoryLdapAuthenticationProvider from Spring Security LDAP library
+ * with additional user information (email)
+ * and conforms authenticated user to [[za.co.absa.logingw.model.User]] class.
+ * */
+class ActiveDirectoryLDAPAuthenticationProvider(config: ActiveDirectoryLDAPConfig) extends AuthenticationProvider {
+
+  private val baseImplementation = {
+    val impl = new SpringSecurityActiveDirectoryLdapAuthenticationProvider(config.domain, config.url)
+
+    impl.setSearchFilter(config.searchFilter)
+    impl.setUserDetailsContextMapper(new LDAPUserDetailsContextMapperWithEmail())
+
+    impl
+  }
+
+  override def authenticate(authentication: Authentication): Authentication = {
+    val fromBase = baseImplementation.authenticate(authentication)
+    val fromBasePrincipal = fromBase.getPrincipal.asInstanceOf[UserDetailsWithEmail]
+
+    val principal = User(
+      fromBasePrincipal.getUsername,
+      fromBasePrincipal.email,
+      fromBasePrincipal.getAuthorities.asScala.map(_.getAuthority).toSeq
+    )
+
+    new UsernamePasswordAuthenticationToken(principal, fromBasePrincipal.getPassword, fromBasePrincipal.getAuthorities)
+  }
+
+  override def supports(authentication: Class[_]): Boolean = baseImplementation.supports(authentication)
+
+
+  private case class UserDetailsWithEmail(userDetails: UserDetails, email: Option[String]) extends UserDetails {
+    override def getAuthorities: util.Collection[_ <: GrantedAuthority] = userDetails.getAuthorities
+    override def getPassword: String = userDetails.getPassword
+    override def getUsername: String = userDetails.getUsername
+    override def isAccountNonExpired: Boolean = userDetails.isAccountNonExpired
+    override def isAccountNonLocked: Boolean = userDetails.isAccountNonLocked
+    override def isCredentialsNonExpired: Boolean = userDetails.isCredentialsNonExpired
+    override def isEnabled: Boolean = userDetails.isEnabled
+  }
+
+  private class LDAPUserDetailsContextMapperWithEmail extends LdapUserDetailsMapper {
+
+    override def mapUserFromContext(
+                                     ctx: DirContextOperations,
+                                     username: String,
+                                     authorities: util.Collection[_ <: GrantedAuthority]
+                                   ): UserDetails = {
+      val fromBase = super.mapUserFromContext(ctx, username, authorities)
+      val email = Option(ctx.getAttributes().get("mail")).map(_.get().toString)
+      UserDetailsWithEmail(fromBase, email)
+    }
+
+  }
+
+}

--- a/service/src/main/scala/za/co/absa/logingw/rest/service/JWTService.scala
+++ b/service/src/main/scala/za/co/absa/logingw/rest/service/JWTService.scala
@@ -29,8 +29,7 @@ import java.time.temporal.ChronoUnit
 import java.util.Date
 
 @Service
-class JWTService @Autowired()(baseConfig: BaseConfig){
-
+class JWTService @Autowired()(baseConfig: BaseConfig) {
 
   private val rsaKeyPair: KeyPair = Keys.keyPairFor(SignatureAlgorithm.valueOf(baseConfig.algName))
 
@@ -45,13 +44,17 @@ class JWTService @Autowired()(baseConfig: BaseConfig){
     // needs to be Java List/Array, otherwise incorrect claim is generated
     val groupsClaim = user.groups.asJava
 
-    Jwts
+    val jwtBuilderWithoutEmail = Jwts
       .builder()
       .setSubject(user.name)
       .setExpiration(expiration)
       .setIssuedAt(issuedAt)
       .claim("groups", groupsClaim)
-      .claim("email", user.email)
+
+    user
+      .email
+      .map(jwtBuilderWithoutEmail.claim("email", _))
+      .getOrElse(jwtBuilderWithoutEmail)
       .signWith(rsaKeyPair.getPrivate)
       .compact()
   }

--- a/service/src/test/scala/za/co/absa/logingw/rest/FakeAuthentication.scala
+++ b/service/src/test/scala/za/co/absa/logingw/rest/FakeAuthentication.scala
@@ -26,7 +26,7 @@ import java.util
 
 object FakeAuthentication {
 
-  val fakeUser: User = User("fakeUser", "fake@gmail.com", Seq.empty)
+  val fakeUser: User = User("fakeUser", Some("fake@gmail.com"), Seq.empty)
 
   val fakeUserAuthentication: Authentication = new UsernamePasswordAuthenticationToken(
     fakeUser, "fakePassword", new util.ArrayList[GrantedAuthority]()

--- a/service/src/test/scala/za/co/absa/logingw/rest/controller/TokenControllerTest.scala
+++ b/service/src/test/scala/za/co/absa/logingw/rest/controller/TokenControllerTest.scala
@@ -57,7 +57,7 @@ class TokenControllerTest extends AnyFlatSpec with ControllerIntegrationTestBase
     )(FakeAuthentication.fakeUserAuthentication)
   }
 
-  it should "return should fail for anonymous (not authenticated) user" in {
+  it should "fail for anonymous (not authenticated) user" in {
     val fakeJWT = "abc.fakeJWTToken.abc"
     when(jwtService.generateToken(any[User]())).thenReturn(fakeJWT)
 

--- a/service/src/test/scala/za/co/absa/logingw/rest/service/JWTServiceTest.scala
+++ b/service/src/test/scala/za/co/absa/logingw/rest/service/JWTServiceTest.scala
@@ -29,10 +29,14 @@ class JWTServiceTest extends AnyFlatSpec {
   private val testConfig = BaseConfig(algName = "RS256", expTime = 2)
   private val jwtService: JWTService = new JWTService(testConfig)
 
-  private val userWithoutGroups: User = User(
+  private val userWithoutEmailAndGroups: User = User(
     name = "testUser",
-    email = "test@gmail.com",
+    email = None,
     groups = Seq.empty
+  )
+
+  private val userWithoutGroups: User = userWithoutEmailAndGroups.copy(
+    email = Some("test@gmail.com")
   )
 
   private val userWithGroups: User = userWithoutGroups.copy(
@@ -62,14 +66,26 @@ class JWTServiceTest extends AnyFlatSpec {
     assert(actualSubject === userWithoutGroups.name)
   }
 
-  it should "return a JWT with email claim equal to User.email" in {
+  it should "return a JWT with email claim equal to User.email if it is not None" in {
     val jwt = jwtService.generateToken(userWithoutGroups)
     val parsedJWT = parseJWT(jwt)
-    val actualSubject = parsedJWT
+
+    val actualEmail = parsedJWT
       .map(_.getBody.get("email", classOf[String]))
       .get
 
-    assert(actualSubject === userWithoutGroups.email)
+    assert(userWithoutGroups.email contains actualEmail)
+  }
+
+  it should "return a JWT without email claim if User.email is None" in {
+    val jwt = jwtService.generateToken(userWithoutEmailAndGroups)
+    val parsedJWT = parseJWT(jwt)
+
+    assert(parsedJWT.isSuccess)
+    parsedJWT.foreach { jwt =>
+      val actualEmail = jwt.getBody.get("email")
+      assert(actualEmail === null)
+    }
   }
 
   it should "turn groups into empty `groups` claim for user without groups" in {


### PR DESCRIPTION
- added me to codeowners/developers
- added AD LDAP auth provider
- made `email` in `User` model an `Option` as service accounts don't have emails

DI of AD LDAP config to be done as part of separate issue (as this should be provider-agnostic work).

Closes #23