### PR TITLE
feature/6: HealthCheck Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ service / Tomcat / start
 ```
 
 ## API documentation:
-Swagger doc site is available at `http://localhost:8080/swagger-ui.html`
-(substitute `http://localhost:8080` with any possible host you have deployed your package to.)
+Swagger doc site is available at `http://localhost:port/swagger-ui.html`
+(substitute `http://localhost:port` with any possible host and port you have deployed your package to.)
 ### Need the OpenAPI 3 yaml file?
-It is available for download while running the service at `http://localhost:8080/v3/api-docs.yaml` - 
+It is available for download while running the service at `http://localhost:port/v3/api-docs.yaml` - 
 gets generated from code (specifically from Spring annotations) 
 
 ## Authentication Providers
@@ -51,3 +51,35 @@ Code coverage will be generated on path:
 ```
 {project-root}/{module}/target/scala-{scala_version}/jacoco/report/html
 ```
+## Health check endpoint
+Springboot Actuator is enabled for this project. This provides the user with an endpoint (readable via HTTP or JMX)
+that describes the overall status of the login-gateway as well as its parts.
+### Accessing health endpoint via http
+Health Endpoint can be accessed via http using the following URL: `http://localhost:port/actuator/health`
+Accessing the above should give you the following Json message if all is functional and healthy:
+```
+    {"status":"UP"}
+```
+If one of the monitored dependencies are unavailable or unhealthy then you will get:
+```
+    {"status":"DOWN"}
+```
+If you wish for a full breakdown of the applications health including all dependencies then add the following to the application.properties file:
+```
+    management.endpoint.health.show-details=always
+```
+The health endpoint is also available via the Swagger: `http://localhost:port/swagger-ui.html`
+### Using JMX to monitor /actuator/health
+Local JMX is currently enabled on the project. In order to utilize it please follow the following steps:
+#### Steps
+1. Start the login-gateway application.
+2. Open a terminal or command prompt and run the following command to start JConsole:
+    ```
+    jconsole
+    ```
+3. In the JConsole window that opens, select the process corresponding to the login-gateway application from the list of local processes.
+4. Click the Connect button. JConsole will connect to the JMX agent running in the login-gateway application.
+5. In the MBean tab, expand the org.springframework.boot domain to see the available JMX endpoints.
+6. Find the health endpoint and click on it to view its attributes and operations. You can use the attributes and operations to check the health of the login-gateway and perform management tasks.
+You can now use JConsole to monitor and manage your local application by accessing the available endpoints.
+Remote JMX is also an option and may be enabled with some config changes in the application.properties file.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -53,8 +53,8 @@ object Dependencies {
   lazy val springDoc = "org.springdoc" % "springdoc-openapi-ui" % "1.6.14"
 
 
-  // TODO bring actuator (health) endpoints in? - Issue #6
-  //lazy val springBootStarterActuator = "org.springframework.boot" % "spring-boot-starter-actuator" % Versions.springBoot
+  // Enables /actuator/health endpoint
+  lazy val springBootStarterActuator = "org.springframework.boot" % "spring-boot-starter-actuator" % Versions.springBoot
 
   lazy val scalaTest = "org.scalatest" %% "scalatest" % Versions.scalatest % Test
   lazy val springBootTest = "org.springframework.boot" % "spring-boot-starter-test" % Versions.springBoot % Test
@@ -78,6 +78,8 @@ object Dependencies {
     jjwtJackson,
 
     springDoc,
+
+    springBootStarterActuator,
 
     scalaTest,
     springBootTest,

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -1,8 +1,24 @@
+#App Config
 server.port = 9090
 spring.application.name = login-gateway
+
+#Rest General Config
 logingw.rest.config.some-key = BETA
 logingw.rest.config.alg-name = RS256
 logingw.rest.config.exp-time = 2
+
+#Rest Auth Config
 logingw.rest.auth.ad.ldap.domain = some.domain.com
 logingw.rest.auth.ad.ldap.url = ldaps://some.domain.com:636/
 logingw.rest.auth.ad.ldap.search-filter = (samaccountname={1})
+
+#Health Check Config
+management.endpoint.health.show-details=never
+management.endpoints.web.exposure.include=health
+#TODO: Enable Ldap check when fully Implemented - issue #20
+management.health.ldap.enabled=false
+springdoc.show-actuator=true
+
+#JMX Config
+spring.jmx.enabled=true
+management.endpoints.jmx.exposure.include=health

--- a/service/src/main/scala/za/co/absa/logingw/rest/SecurityConfig.scala
+++ b/service/src/main/scala/za/co/absa/logingw/rest/SecurityConfig.scala
@@ -44,6 +44,7 @@ class SecurityConfig {
         "/swagger-ui/**", "/swagger-ui.html", // "/swagger-ui.html" redirects to "/swagger-ui/index.html
         "/swagger-resources/**", "/v3/api-docs/**", // swagger needs these
         "/info",
+        "/actuator/**",
         "/token/public-key").permitAll()
         .anyRequest().authenticated()
         .and()

--- a/service/src/test/scala/za/co/absa/logingw/rest/actuator/ActuatorHealthTest.scala
+++ b/service/src/test/scala/za/co/absa/logingw/rest/actuator/ActuatorHealthTest.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.logingw.rest.actuator
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.actuate.health.{Health, HealthEndpoint, HealthIndicator, Status}
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.{TestContextManager, TestPropertySource}
+
+@SpringBootTest
+class ActuatorHealthTest extends AnyFlatSpec with Matchers {
+
+  @Autowired
+  private var healthService: HealthEndpoint = _
+
+  // Makes the above autowired work
+  new TestContextManager(this.getClass).prepareTestInstance(this)
+
+  "The Overall HealthEndpoint Status" should "return UP" in {
+    val health = healthService.health()
+    assert(health.getStatus == Status.UP)
+  }
+  //TODO: Add more tests for each dependency (Example Ldap when implemented fully) - issue #20
+}


### PR DESCRIPTION
- Implemented Actuator/Health Endpoint which checks: Server Storage and Ldap connectivity (Currently disabled in Config until pointing to a proper URL)
- Health Endpoint is part of exceptions in Security config, so no need to login for it.
- Added Test for Endpoint (Not in Flatspec, may need help to transform it into Flatspec?)
- Added JWX monitoring
- Added Jconsole instructions to ReadMe for JWX
- Organized Config a bit (Will probably need to be redone but just for improved readability)